### PR TITLE
Add mssql tools to PATH

### DIFF
--- a/src/mssql-odbc-driver/install.sh
+++ b/src/mssql-odbc-driver/install.sh
@@ -70,6 +70,14 @@ install_using_apt() {
         rm -f /etc/apt/sources.list.d/mssql-release.list
         return 1
     fi
+    
+    # Add to PATH
+    if [ $ODBC_VERSION -eq "18" ]; then
+        echo 'export PATH="$PATH:/opt/mssql-tools18/bin"' >> ~/.bashrc
+    else
+        echo 'export PATH="$PATH:/opt/mssql-tools/bin"' >> ~/.bashrc
+    fi
+    source ~/.bashrc
 }
 
 echo "(*) Installing SQL Server ODBC Driver..."


### PR DESCRIPTION
Getting an error when trying to use the library with pyodbc, and believe its related to the tools not being added to PATH

```
  │ pyodbc.Error: ('01000', "[01000] [unixODBC][Driver Manager]Can't open lib
  │ 'ODBC Driver 18 for SQL Server' : file not found (0) (SQLDriverConnect)")
```

As per the [docs](https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server?view=sql-server-ver15&tabs=debian18-install%2Calpine17-install%2Cdebian8-install%2Credhat7-13-install%2Crhel7-offline#18) the add to path steps appear to be missing, so proposing to add them