### PR TITLE
update MICROSOFT_GPG_KEYS_URI

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,9 +16,10 @@ jobs:
           - azure-functions-core-tools
           - mssql-odbc-driver
         baseImage:
-          - debian:11
+          - debian:12
           - debian:latest
           - ubuntu:22.04
+          - ubuntu:24.04
           - ubuntu:latest
           - mcr.microsoft.com/devcontainers/base:ubuntu
     steps:

--- a/src/azure-functions-core-tools/devcontainer-feature.json
+++ b/src/azure-functions-core-tools/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "azure-functions-core-tools",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "name": "Azure Functions Core Tools",
   "documentationURL": "https://github.com/jlaundry/devcontainer-features/tree/main/src/azure-functions-core-tools",
   "description": "Installs the Azure Functions Core Tools along with needed dependencies. Useful for developing Azure Function apps inside codespaces.",

--- a/src/azure-functions-core-tools/install.sh
+++ b/src/azure-functions-core-tools/install.sh
@@ -14,7 +14,20 @@ rm -rf /var/lib/apt/lists/*
 
 AZ_VERSION=${VERSION:-"latest"}
 
-MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc"
+OS_VERSION_ID="$(source /etc/os-release; echo "${ID}:${VERSION_ID}")"
+case $OS_VERSION_ID in
+    debian:10) MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc" ;;
+    debian:11) MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc" ;;
+    debian:12) MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc" ;;
+    debian:13) MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft-2025.asc" ;;
+    ubuntu:20.04) MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc" ;;
+    ubuntu:22.04) MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc" ;;
+    ubuntu:24.04) MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc" ;;
+    ubuntu:26.04) MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft-2025.asc" ;;
+    *) MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft-2025.asc" ;;
+esac
+
+echo "using Microsoft GPG key ${MICROSOFT_GPG_KEYS_URI} for ${OS_VERSION_ID}"
 
 if [ "$(id -u)" -ne 0 ]; then
     echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
@@ -102,8 +115,8 @@ install_using_apt() {
     check_packages apt-transport-https curl ca-certificates gnupg2 dirmngr
     # Import key safely (new 'signed-by' method rather than deprecated apt-key approach) and install
     get_common_setting MICROSOFT_GPG_KEYS_URI
-    curl -sSL ${MICROSOFT_GPG_KEYS_URI} | gpg --dearmor > /usr/share/keyrings/microsoft-archive-keyring.gpg
-    echo "deb [arch=${architecture} signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/$ID/$VERSION_ID/prod ${VERSION_CODENAME} main" > /etc/apt/sources.list.d/azure-functions-core-tools.list
+    curl -sSL ${MICROSOFT_GPG_KEYS_URI} | gpg --dearmor > /usr/share/keyrings/microsoft-prod.gpg
+    echo "deb [arch=${architecture} signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/$ID/$VERSION_ID/prod ${VERSION_CODENAME} main" > /etc/apt/sources.list.d/azure-functions-core-tools.list
     apt-get update
 
     if [ "${AZ_VERSION}" = "latest" ] || [ "${AZ_VERSION}" = "lts" ] || [ "${AZ_VERSION}" = "stable" ]; then

--- a/src/azure-functions-core-tools/install.sh
+++ b/src/azure-functions-core-tools/install.sh
@@ -111,10 +111,12 @@ apt_cache_version_soft_match() {
 }
 
 install_using_apt() {
+    echo "installing azure-functions-core-tools with AZ_VERSION=${AZ_VERSION} using MICROSOFT_GPG_KEYS_URI=${MICROSOFT_GPG_KEYS_URI} on ${architecture}"
+    
     # Install dependencies
     check_packages apt-transport-https curl ca-certificates gnupg2 dirmngr
+
     # Import key safely (new 'signed-by' method rather than deprecated apt-key approach) and install
-    get_common_setting MICROSOFT_GPG_KEYS_URI
     curl -sSL ${MICROSOFT_GPG_KEYS_URI} | gpg --dearmor > /usr/share/keyrings/microsoft-prod.gpg
     echo "deb [arch=${architecture} signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/$ID/$VERSION_ID/prod ${VERSION_CODENAME} main" > /etc/apt/sources.list.d/azure-functions-core-tools.list
     apt-get update

--- a/src/mssql-odbc-driver/devcontainer-feature.json
+++ b/src/mssql-odbc-driver/devcontainer-feature.json
@@ -1,6 +1,6 @@
 {
   "id": "mssql-odbc-driver",
-  "version": "1.0.2",
+  "version": "1.0.3",
   "name": "SQL Server ODBC Driver",
   "documentationURL": "https://github.com/jlaundry/devcontainer-features/tree/main/src/mssql-odbc-driver",
   "description": "Installs the Microsoft SQL Server ODBC Driver.",

--- a/src/mssql-odbc-driver/install.sh
+++ b/src/mssql-odbc-driver/install.sh
@@ -12,7 +12,7 @@ set -e
 # Clean up
 rm -rf /var/lib/apt/lists/*
 
-ODBC_VERSION=${VERSION:-"latest"}
+ODBC_VERSION=${VERSION:-"18"}
 
 OS_VERSION_ID="$(source /etc/os-release; echo "${ID}:${VERSION_ID}")"
 case $OS_VERSION_ID in
@@ -64,10 +64,11 @@ export DEBIAN_FRONTEND=noninteractive
 
 
 install_using_apt() {
+    echo "installing msodbcsql withODBC_VERSION=${ODBC_VERSION} using MICROSOFT_GPG_KEYS_URI=${MICROSOFT_GPG_KEYS_URI} on ${architecture}"
     # Install dependencies
     check_packages apt-transport-https curl ca-certificates gnupg2 dirmngr
+
     # Import key safely (new 'signed-by' method rather than deprecated apt-key approach) and install
-    get_common_setting MICROSOFT_GPG_KEYS_URI
     curl -sSL ${MICROSOFT_GPG_KEYS_URI} | gpg --dearmor > /usr/share/keyrings/microsoft-prod.gpg
 
     echo "deb [arch=${architecture} signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/$ID/$VERSION_ID/prod ${VERSION_CODENAME} main" > /etc/apt/sources.list.d/mssql-release.list

--- a/src/mssql-odbc-driver/install.sh
+++ b/src/mssql-odbc-driver/install.sh
@@ -14,7 +14,20 @@ rm -rf /var/lib/apt/lists/*
 
 ODBC_VERSION=${VERSION:-"latest"}
 
-MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc"
+OS_VERSION_ID="$(source /etc/os-release; echo "${ID}:${VERSION_ID}")"
+case $OS_VERSION_ID in
+    debian:10) MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc" ;;
+    debian:11) MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc" ;;
+    debian:12) MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc" ;;
+    debian:13) MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft-2025.asc" ;;
+    ubuntu:20.04) MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc" ;;
+    ubuntu:22.04) MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc" ;;
+    ubuntu:24.04) MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft.asc" ;;
+    ubuntu:26.04) MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft-2025.asc" ;;
+    *) MICROSOFT_GPG_KEYS_URI="https://packages.microsoft.com/keys/microsoft-2025.asc" ;;
+esac
+
+echo "using Microsoft GPG key ${MICROSOFT_GPG_KEYS_URI} for ${OS_VERSION_ID}"
 
 if [ "$(id -u)" -ne 0 ]; then
     echo -e 'Script must be run as root. Use sudo, su, or add "USER root" to your Dockerfile before running this script.'
@@ -55,9 +68,9 @@ install_using_apt() {
     check_packages apt-transport-https curl ca-certificates gnupg2 dirmngr
     # Import key safely (new 'signed-by' method rather than deprecated apt-key approach) and install
     get_common_setting MICROSOFT_GPG_KEYS_URI
-    curl -sSL ${MICROSOFT_GPG_KEYS_URI} | gpg --dearmor > /usr/share/keyrings/microsoft-archive-keyring.gpg
+    curl -sSL ${MICROSOFT_GPG_KEYS_URI} | gpg --dearmor > /usr/share/keyrings/microsoft-prod.gpg
 
-    echo "deb [arch=${architecture} signed-by=/usr/share/keyrings/microsoft-archive-keyring.gpg] https://packages.microsoft.com/$ID/$VERSION_ID/prod ${VERSION_CODENAME} main" > /etc/apt/sources.list.d/mssql-release.list
+    echo "deb [arch=${architecture} signed-by=/usr/share/keyrings/microsoft-prod.gpg] https://packages.microsoft.com/$ID/$VERSION_ID/prod ${VERSION_CODENAME} main" > /etc/apt/sources.list.d/mssql-release.list
     apt-get update
 
     if [ $ODBC_VERSION -eq "18" ]; then


### PR DESCRIPTION
As per https://learn.microsoft.com/en-us/linux/packages, the Debian 13, Ubuntu 25.10 (therefore 26.04), and RHEL 10 package repos are signed by a new GPG key because of SHA-1 deprecation.

We also needed to remove `get_common_setting MICROSOFT_GPG_KEYS_URI`, because https://aka.ms/vscode-dev-containers/script-library/settings.env is currently hard-coded to the old key